### PR TITLE
Enable rife-v4 for ncnn

### DIFF
--- a/Code/Os/AiProcess.cs
+++ b/Code/Os/AiProcess.cs
@@ -275,9 +275,23 @@ namespace Flowframes.Os
             string uhdStr = await InterpolateUtils.UseUhd() ? "-u" : "";
             string ttaStr = Config.GetBool(Config.Key.rifeNcnnUseTta, false) ? "-x" : "";
 
-            rifeNcnn.StartInfo.Arguments = $"{OsUtils.GetCmdArg()} cd /D {Path.Combine(Paths.GetPkgPath(), Implementations.rifeNcnn.pkgDir).Wrap()} & rife-ncnn-vulkan.exe " +
+            if (mdl.ToLower() == "rife-v4")
+            {
+
+                rifeNcnn.StartInfo.Arguments = $"{OsUtils.GetCmdArg()} cd /D {Path.Combine(Paths.GetPkgPath(), Implementations.rifeNcnn.pkgDir).Wrap()} & rife-ncnn-vulkan-v4.exe " +
                 $" -v -i {inPath.Wrap()} -o {outPath.Wrap()} -n {targetFrames} -m {mdl.ToLower()} {ttaStr} {uhdStr} -g {Config.Get(Config.Key.ncnnGpus)} -f {GetNcnnPattern()} -j {GetNcnnThreads()}";
-            
+
+            }
+
+            else
+
+            {
+               
+                rifeNcnn.StartInfo.Arguments = $"{OsUtils.GetCmdArg()} cd /D {Path.Combine(Paths.GetPkgPath(), Implementations.rifeNcnn.pkgDir).Wrap()} & rife-ncnn-vulkan.exe " +
+            $" -v -i {inPath.Wrap()} -o {outPath.Wrap()} -m {mdl.ToLower()} {ttaStr} {uhdStr} -g {Config.Get(Config.Key.ncnnGpus)} -f {GetNcnnPattern()} -j {GetNcnnThreads()}";
+
+            }
+
             Logger.Log("cmd.exe " + rifeNcnn.StartInfo.Arguments, true);
            
             if (!OsUtils.ShowHiddenCmd())

--- a/Pkgs/rife-ncnn/models.json
+++ b/Pkgs/rife-ncnn/models.json
@@ -18,6 +18,11 @@
 	"name": "RIFE 3.1",
 	"desc": "Latest General Model",
 	"dir": "rife-v3.1",
+},
+{
+	"name": "RIFE 4.0",
+	"desc": "Latest General Model",
+	"dir": "rife-v4",
 	"isDefault": "true"
-}
+},
 ]


### PR DESCRIPTION
Enable RIFE40 support for Vulkan.
Updates models.json to now include rife-v4 and adds the [new rife-ncnn-vulkan.exe](https://github.com/nihui/rife-ncnn-vulkan/releases/tag/20220330).