### PR TITLE
Update AI.cs

### DIFF
--- a/Code/Data/AI.cs
+++ b/Code/Data/AI.cs
@@ -18,7 +18,7 @@ namespace Flowframes.Data
         public string NameLong { get; set; } = "";
         public string FriendlyName { get { return $"{NameShort} ({GetFrameworkString(Backend)})"; } }
         public string Description { get { return $"{GetImplemString(Backend)} of {NameShort}{(Backend == AiBackend.Pytorch ? " (Nvidia Only!)" : "")}"; } }
-        public string PkgDir { get { return NameInternal.Replace("_", "-").ToLower(); } }
+        public string PkgDir { get { return NameInternal.Replace("_", "-").ToLowerInvariant(); } }
         public enum InterpFactorSupport { Fixed, AnyPowerOfTwo, AnyInteger, AnyFloat }
         public InterpFactorSupport FactorSupport { get; set; } = InterpFactorSupport.Fixed;
         public int[] SupportedFactors { get; set; } = new int[0];


### PR DESCRIPTION
Changed lowercase conversion method from .ToLower() to .ToLowerInvariant() in order to make it work with Turkish regional settings. If not forced to make an Invariant conversion, .NET converts capital "I" to lowercase "ı" which is linguistically correct for Turkish but fails for file paths thus leading the "can't load AI models for this implementation!" error.