### PR TITLE
- Naturalsort has been implemented in rife.py. Natsort must be includ…

### DIFF
--- a/Code/Data/InterpSettings.cs
+++ b/Code/Data/InterpSettings.cs
@@ -102,6 +102,7 @@ namespace Flowframes
             _inputResolution = new Size(0, 0);
             framesExt = "";
             interpExt = "";
+            
 
             Dictionary<string, string> entries = new Dictionary<string, string>();
 
@@ -215,11 +216,12 @@ namespace Flowframes
                     framesExt = (Config.GetBool(Config.Key.jpegFrames) ? ".jpg" : ".png");
 
                 if (type == FrameType.Both || type == FrameType.Interp)
-                    interpExt = (Config.GetBool(Config.Key.jpegInterp) ? ".jpg" : ".png");
+                    interpExt = (Config.GetString(Config.Key.formatofInterp) == "png" ? ".png" : ".jpg");
             }
 
             Logger.Log($"RefreshExtensions - Using '{framesExt}' for imported frames, using '{interpExt}' for interpolated frames", true);
         }
+
 
         public string Serialize ()
         {

--- a/Code/Extensions/ExtensionMethods.cs
+++ b/Code/Extensions/ExtensionMethods.cs
@@ -129,13 +129,24 @@ namespace Flowframes
             return i;
         }
 
-        public static string[] SplitIntoLines(this string str)
+/*        public static string[] SplitIntoLines(this string str)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return new string[0];
 
             return Regex.Split(str, "\r\n|\r|\n");
+        }*/
+
+        public static string[] SplitIntoLines(this string str)
+        {
+            if (string.IsNullOrWhiteSpace(str))
+                return new string[0];
+
+            return str.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
         }
+
+
+
 
         public static string Trunc(this string inStr, int maxChars, bool addEllipsis = true)
         {

--- a/Code/Flowframes.csproj
+++ b/Code/Flowframes.csproj
@@ -70,7 +70,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
@@ -422,6 +422,7 @@
     <Compile Include="IO\ConfigParser.cs" />
     <Compile Include="IO\ModelDownloader.cs" />
     <Compile Include="IO\Symlinks.cs" />
+    <Compile Include="IO\TSource.cs" />
     <Compile Include="Magick\Blend.cs" />
     <Compile Include="Magick\MagickExtensions.cs" />
     <Compile Include="Magick\SceneDetect.cs" />
@@ -493,6 +494,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\BatchForm.resx">
       <DependentUpon>BatchForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\BigPreviewForm.resx">
       <DependentUpon>BigPreviewForm.cs</DependentUpon>
@@ -547,7 +549,7 @@
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 und x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/Code/Forms/Main/Form1.Designer.cs
+++ b/Code/Forms/Main/Form1.Designer.cs
@@ -140,10 +140,11 @@
             this.stepSelector = new System.Windows.Forms.ComboBox();
             this.busyControlsPanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.pauseBtn = new System.Windows.Forms.Button();
             this.cancelBtn = new System.Windows.Forms.Button();
+            this.pauseBtn = new System.Windows.Forms.Button();
             this.menuStripQueue = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.addCurrentConfigurationToQueueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.textBox1 = new System.Windows.Forms.TextBox();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
@@ -175,12 +176,12 @@
             // titleLabel
             // 
             this.titleLabel.AutoSize = true;
-            this.titleLabel.Font = new System.Drawing.Font("Yu Gothic UI", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.titleLabel.Font = new System.Drawing.Font("Yu Gothic UI", 20.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.titleLabel.ForeColor = System.Drawing.Color.White;
             this.titleLabel.Location = new System.Drawing.Point(12, 9);
             this.titleLabel.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
             this.titleLabel.Name = "titleLabel";
-            this.titleLabel.Size = new System.Drawing.Size(404, 40);
+            this.titleLabel.Size = new System.Drawing.Size(377, 37);
             this.titleLabel.TabIndex = 0;
             this.titleLabel.Text = "Flowframes Video Interpolator";
             // 
@@ -191,9 +192,9 @@
             this.aiModel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.aiModel.ForeColor = System.Drawing.Color.White;
             this.aiModel.FormattingEnabled = true;
-            this.aiModel.Location = new System.Drawing.Point(281, 126);
+            this.aiModel.Location = new System.Drawing.Point(235, 125);
             this.aiModel.Name = "aiModel";
-            this.aiModel.Size = new System.Drawing.Size(400, 23);
+            this.aiModel.Size = new System.Drawing.Size(446, 23);
             this.aiModel.TabIndex = 25;
             // 
             // aiCombox
@@ -203,9 +204,9 @@
             this.aiCombox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.aiCombox.ForeColor = System.Drawing.Color.White;
             this.aiCombox.FormattingEnabled = true;
-            this.aiCombox.Location = new System.Drawing.Point(281, 7);
+            this.aiCombox.Location = new System.Drawing.Point(235, 7);
             this.aiCombox.Name = "aiCombox";
-            this.aiCombox.Size = new System.Drawing.Size(400, 23);
+            this.aiCombox.Size = new System.Drawing.Size(446, 23);
             this.aiCombox.TabIndex = 21;
             this.aiCombox.SelectedIndexChanged += new System.EventHandler(this.aiCombox_SelectedIndexChanged);
             // 
@@ -272,11 +273,11 @@
             // 
             this.fpsInTbox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.fpsInTbox.ForeColor = System.Drawing.Color.White;
-            this.fpsInTbox.Location = new System.Drawing.Point(281, 97);
+            this.fpsInTbox.Location = new System.Drawing.Point(235, 97);
             this.fpsInTbox.MinimumSize = new System.Drawing.Size(4, 21);
             this.fpsInTbox.Name = "fpsInTbox";
             this.fpsInTbox.ReadOnly = true;
-            this.fpsInTbox.Size = new System.Drawing.Size(100, 23);
+            this.fpsInTbox.Size = new System.Drawing.Size(146, 23);
             this.fpsInTbox.TabIndex = 8;
             this.fpsInTbox.Text = "0";
             this.fpsInTbox.TextChanged += new System.EventHandler(this.fpsInTbox_TextChanged);
@@ -308,13 +309,12 @@
             // 
             // outputTbox
             // 
-            this.outputTbox.AllowDrop = true;
             this.outputTbox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.outputTbox.ForeColor = System.Drawing.Color.White;
-            this.outputTbox.Location = new System.Drawing.Point(281, 67);
+            this.outputTbox.Location = new System.Drawing.Point(235, 67);
             this.outputTbox.MinimumSize = new System.Drawing.Size(4, 21);
             this.outputTbox.Name = "outputTbox";
-            this.outputTbox.Size = new System.Drawing.Size(400, 23);
+            this.outputTbox.Size = new System.Drawing.Size(446, 23);
             this.outputTbox.TabIndex = 4;
             this.outputTbox.DragDrop += new System.Windows.Forms.DragEventHandler(this.outputTbox_DragDrop);
             this.outputTbox.DragEnter += new System.Windows.Forms.DragEventHandler(this.outputTbox_DragEnter);
@@ -324,10 +324,10 @@
             this.inputTbox.AllowDrop = true;
             this.inputTbox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.inputTbox.ForeColor = System.Drawing.Color.White;
-            this.inputTbox.Location = new System.Drawing.Point(281, 37);
+            this.inputTbox.Location = new System.Drawing.Point(235, 37);
             this.inputTbox.MinimumSize = new System.Drawing.Size(4, 21);
             this.inputTbox.Name = "inputTbox";
-            this.inputTbox.Size = new System.Drawing.Size(400, 23);
+            this.inputTbox.Size = new System.Drawing.Size(446, 23);
             this.inputTbox.TabIndex = 2;
             this.inputTbox.DragDrop += new System.Windows.Forms.DragEventHandler(this.inputTbox_DragDrop);
             this.inputTbox.DragEnter += new System.Windows.Forms.DragEventHandler(this.inputTbox_DragEnter);
@@ -412,14 +412,14 @@
             // 
             // runBtn
             // 
-            this.runBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.runBtn.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.runBtn.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(48)))), ((int)(((byte)(48)))), ((int)(((byte)(48)))));
             this.runBtn.Enabled = false;
             this.runBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.runBtn.ForeColor = System.Drawing.Color.White;
-            this.runBtn.Location = new System.Drawing.Point(12, 418);
+            this.runBtn.Location = new System.Drawing.Point(8, 357);
             this.runBtn.Name = "runBtn";
-            this.runBtn.Size = new System.Drawing.Size(203, 71);
+            this.runBtn.Size = new System.Drawing.Size(208, 77);
             this.runBtn.TabIndex = 2;
             this.runBtn.Text = "Interpolate!";
             this.runBtn.UseVisualStyleBackColor = false;
@@ -435,7 +435,7 @@
             this.progressCircle.InnerColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(32)))), ((int)(((byte)(32)))));
             this.progressCircle.InnerMargin = 2;
             this.progressCircle.InnerWidth = -1;
-            this.progressCircle.Location = new System.Drawing.Point(422, 12);
+            this.progressCircle.Location = new System.Drawing.Point(423, 6);
             this.progressCircle.MarqueeAnimationSpeed = 2000;
             this.progressCircle.Name = "progressCircle";
             this.progressCircle.OuterColor = System.Drawing.Color.Gray;
@@ -463,13 +463,13 @@
             this.logBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.logBox.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.logBox.ForeColor = System.Drawing.Color.White;
-            this.logBox.Location = new System.Drawing.Point(221, 357);
+            this.logBox.Location = new System.Drawing.Point(222, 321);
             this.logBox.MinimumSize = new System.Drawing.Size(4, 21);
             this.logBox.Multiline = true;
             this.logBox.Name = "logBox";
             this.logBox.ReadOnly = true;
             this.logBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.logBox.Size = new System.Drawing.Size(701, 111);
+            this.logBox.Size = new System.Drawing.Size(709, 86);
             this.logBox.TabIndex = 5;
             this.logBox.TabStop = false;
             this.logBox.Text = "Welcome to Flowframes!";
@@ -495,16 +495,16 @@
             this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panel1.Controls.Add(this.statusLabel);
             this.panel1.Controls.Add(this.label12);
-            this.panel1.Location = new System.Drawing.Point(13, 357);
+            this.panel1.Location = new System.Drawing.Point(8, 321);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(203, 55);
+            this.panel1.Size = new System.Drawing.Size(208, 30);
             this.panel1.TabIndex = 6;
             // 
             // statusLabel
             // 
             this.statusLabel.AutoSize = true;
             this.statusLabel.ForeColor = System.Drawing.Color.White;
-            this.statusLabel.Location = new System.Drawing.Point(8, 30);
+            this.statusLabel.Location = new System.Drawing.Point(49, 7);
             this.statusLabel.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
             this.statusLabel.Name = "statusLabel";
             this.statusLabel.Size = new System.Drawing.Size(61, 13);
@@ -521,7 +521,7 @@
             this.updateBtn.ForeColor = System.Drawing.Color.White;
             this.updateBtn.ImageIndex = 0;
             this.updateBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.updateBtn.Location = new System.Drawing.Point(790, 12);
+            this.updateBtn.Location = new System.Drawing.Point(790, 6);
             this.updateBtn.Name = "updateBtn";
             this.updateBtn.Size = new System.Drawing.Size(40, 40);
             this.updateBtn.TabIndex = 41;
@@ -539,7 +539,7 @@
             this.queueBtn.ForeColor = System.Drawing.Color.White;
             this.queueBtn.ImageIndex = 0;
             this.queueBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.queueBtn.Location = new System.Drawing.Point(836, 12);
+            this.queueBtn.Location = new System.Drawing.Point(836, 6);
             this.queueBtn.Name = "queueBtn";
             this.queueBtn.Size = new System.Drawing.Size(40, 40);
             this.queueBtn.TabIndex = 39;
@@ -593,7 +593,7 @@
             this.settingsBtn.ForeColor = System.Drawing.Color.White;
             this.settingsBtn.ImageIndex = 0;
             this.settingsBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.settingsBtn.Location = new System.Drawing.Point(882, 12);
+            this.settingsBtn.Location = new System.Drawing.Point(882, 6);
             this.settingsBtn.Name = "settingsBtn";
             this.settingsBtn.Size = new System.Drawing.Size(40, 40);
             this.settingsBtn.TabIndex = 38;
@@ -611,7 +611,7 @@
             this.patreonBtn.ForeColor = System.Drawing.Color.White;
             this.patreonBtn.ImageIndex = 0;
             this.patreonBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.patreonBtn.Location = new System.Drawing.Point(606, 12);
+            this.patreonBtn.Location = new System.Drawing.Point(606, 6);
             this.patreonBtn.Name = "patreonBtn";
             this.patreonBtn.Size = new System.Drawing.Size(40, 40);
             this.patreonBtn.TabIndex = 37;
@@ -629,7 +629,7 @@
             this.paypalBtn.ForeColor = System.Drawing.Color.White;
             this.paypalBtn.ImageIndex = 0;
             this.paypalBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.paypalBtn.Location = new System.Drawing.Point(559, 12);
+            this.paypalBtn.Location = new System.Drawing.Point(560, 6);
             this.paypalBtn.Name = "paypalBtn";
             this.paypalBtn.Size = new System.Drawing.Size(40, 40);
             this.paypalBtn.TabIndex = 36;
@@ -647,7 +647,7 @@
             this.discordBtn.ForeColor = System.Drawing.Color.White;
             this.discordBtn.ImageIndex = 0;
             this.discordBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.discordBtn.Location = new System.Drawing.Point(652, 12);
+            this.discordBtn.Location = new System.Drawing.Point(652, 6);
             this.discordBtn.Name = "discordBtn";
             this.discordBtn.Size = new System.Drawing.Size(40, 40);
             this.discordBtn.TabIndex = 35;
@@ -719,7 +719,7 @@
             this.debugBtn.ForeColor = System.Drawing.Color.White;
             this.debugBtn.ImageIndex = 0;
             this.debugBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.debugBtn.Location = new System.Drawing.Point(744, 12);
+            this.debugBtn.Location = new System.Drawing.Point(744, 9);
             this.debugBtn.Name = "debugBtn";
             this.debugBtn.Size = new System.Drawing.Size(40, 40);
             this.debugBtn.TabIndex = 75;
@@ -753,9 +753,9 @@
             // 
             this.longProgBar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.longProgBar.BorderThickness = 0;
-            this.longProgBar.Location = new System.Drawing.Point(221, 474);
+            this.longProgBar.Location = new System.Drawing.Point(222, 413);
             this.longProgBar.Name = "longProgBar";
-            this.longProgBar.Size = new System.Drawing.Size(700, 15);
+            this.longProgBar.Size = new System.Drawing.Size(709, 20);
             this.longProgBar.TabIndex = 33;
             // 
             // mainTabControl
@@ -774,13 +774,13 @@
             this.mainTabControl.HoverTabButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(82)))), ((int)(((byte)(176)))), ((int)(((byte)(239)))));
             this.mainTabControl.HoverTabColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(63)))), ((int)(((byte)(70)))));
             this.mainTabControl.HoverUnselectedTabButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(85)))), ((int)(((byte)(85)))), ((int)(((byte)(85)))));
-            this.mainTabControl.Location = new System.Drawing.Point(13, 62);
+            this.mainTabControl.Location = new System.Drawing.Point(4, 62);
             this.mainTabControl.Name = "mainTabControl";
             this.mainTabControl.Padding = new System.Drawing.Point(14, 4);
             this.mainTabControl.SelectedIndex = 0;
             this.mainTabControl.SelectedTabButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(151)))), ((int)(((byte)(234)))));
             this.mainTabControl.SelectedTabColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(122)))), ((int)(((byte)(204)))));
-            this.mainTabControl.Size = new System.Drawing.Size(909, 289);
+            this.mainTabControl.Size = new System.Drawing.Size(927, 257);
             this.mainTabControl.TabIndex = 4;
             this.mainTabControl.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
             this.mainTabControl.UnderBorderTabLineColor = System.Drawing.Color.FromArgb(((int)(((byte)(67)))), ((int)(((byte)(67)))), ((int)(((byte)(70)))));
@@ -802,7 +802,7 @@
             this.welcomeTab.Location = new System.Drawing.Point(4, 27);
             this.welcomeTab.Name = "welcomeTab";
             this.welcomeTab.Padding = new System.Windows.Forms.Padding(3);
-            this.welcomeTab.Size = new System.Drawing.Size(901, 258);
+            this.welcomeTab.Size = new System.Drawing.Size(919, 226);
             this.welcomeTab.TabIndex = 4;
             this.welcomeTab.Text = "Welcome";
             // 
@@ -828,7 +828,7 @@
             this.panel8.Location = new System.Drawing.Point(593, 57);
             this.panel8.Margin = new System.Windows.Forms.Padding(5);
             this.panel8.Name = "panel8";
-            this.panel8.Size = new System.Drawing.Size(300, 193);
+            this.panel8.Size = new System.Drawing.Size(326, 161);
             this.panel8.TabIndex = 4;
             // 
             // patronsLabel
@@ -862,7 +862,7 @@
             this.panel6.Location = new System.Drawing.Point(8, 57);
             this.panel6.Margin = new System.Windows.Forms.Padding(5);
             this.panel6.Name = "panel6";
-            this.panel6.Size = new System.Drawing.Size(575, 193);
+            this.panel6.Size = new System.Drawing.Size(575, 161);
             this.panel6.TabIndex = 3;
             // 
             // newsLabel
@@ -936,7 +936,7 @@
             this.interpOptsTab.Location = new System.Drawing.Point(4, 27);
             this.interpOptsTab.Name = "interpOptsTab";
             this.interpOptsTab.Padding = new System.Windows.Forms.Padding(3);
-            this.interpOptsTab.Size = new System.Drawing.Size(901, 258);
+            this.interpOptsTab.Size = new System.Drawing.Size(919, 226);
             this.interpOptsTab.TabIndex = 0;
             this.interpOptsTab.Text = "Interpolation";
             this.interpOptsTab.DragDrop += new System.Windows.Forms.DragEventHandler(this.Form1_DragDrop);
@@ -960,9 +960,9 @@
             this.flowLayoutPanel1.Controls.Add(this.comboxOutputQuality);
             this.flowLayoutPanel1.Controls.Add(this.textboxOutputQualityCust);
             this.flowLayoutPanel1.Controls.Add(this.comboxOutputColors);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(281, 157);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(235, 160);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(614, 23);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(449, 23);
             this.flowLayoutPanel1.TabIndex = 46;
             // 
             // comboxOutputFormat
@@ -984,7 +984,7 @@
             this.comboxOutputFormat.Location = new System.Drawing.Point(0, 0);
             this.comboxOutputFormat.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
             this.comboxOutputFormat.Name = "comboxOutputFormat";
-            this.comboxOutputFormat.Size = new System.Drawing.Size(75, 23);
+            this.comboxOutputFormat.Size = new System.Drawing.Size(93, 23);
             this.comboxOutputFormat.TabIndex = 47;
             this.comboxOutputFormat.SelectedIndexChanged += new System.EventHandler(this.comboxOutputFormat_SelectedIndexChanged);
             // 
@@ -1004,10 +1004,10 @@
             "Animated GIF (Only supports up to 50 FPS)",
             "Image Sequence (PNG, JPG, WEBP)",
             "Real-time Interpolation (Video only)"});
-            this.comboxOutputEncoder.Location = new System.Drawing.Point(81, 0);
+            this.comboxOutputEncoder.Location = new System.Drawing.Point(99, 0);
             this.comboxOutputEncoder.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
             this.comboxOutputEncoder.Name = "comboxOutputEncoder";
-            this.comboxOutputEncoder.Size = new System.Drawing.Size(90, 23);
+            this.comboxOutputEncoder.Size = new System.Drawing.Size(96, 23);
             this.comboxOutputEncoder.TabIndex = 50;
             this.comboxOutputEncoder.SelectedIndexChanged += new System.EventHandler(this.comboxOutputEncoder_SelectedIndexChanged);
             // 
@@ -1018,7 +1018,7 @@
             this.comboxOutputQuality.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.comboxOutputQuality.ForeColor = System.Drawing.Color.White;
             this.comboxOutputQuality.FormattingEnabled = true;
-            this.comboxOutputQuality.Location = new System.Drawing.Point(177, 0);
+            this.comboxOutputQuality.Location = new System.Drawing.Point(201, 0);
             this.comboxOutputQuality.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
             this.comboxOutputQuality.Name = "comboxOutputQuality";
             this.comboxOutputQuality.Size = new System.Drawing.Size(100, 23);
@@ -1030,7 +1030,7 @@
             this.textboxOutputQualityCust.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.textboxOutputQualityCust.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.textboxOutputQualityCust.ForeColor = System.Drawing.Color.White;
-            this.textboxOutputQualityCust.Location = new System.Drawing.Point(283, 0);
+            this.textboxOutputQualityCust.Location = new System.Drawing.Point(307, 0);
             this.textboxOutputQualityCust.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
             this.textboxOutputQualityCust.MaxLength = 3;
             this.textboxOutputQualityCust.MinimumSize = new System.Drawing.Size(4, 21);
@@ -1047,10 +1047,10 @@
             this.comboxOutputColors.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.comboxOutputColors.ForeColor = System.Drawing.Color.White;
             this.comboxOutputColors.FormattingEnabled = true;
-            this.comboxOutputColors.Location = new System.Drawing.Point(319, 0);
+            this.comboxOutputColors.Location = new System.Drawing.Point(343, 0);
             this.comboxOutputColors.Margin = new System.Windows.Forms.Padding(0);
             this.comboxOutputColors.Name = "comboxOutputColors";
-            this.comboxOutputColors.Size = new System.Drawing.Size(117, 23);
+            this.comboxOutputColors.Size = new System.Drawing.Size(103, 23);
             this.comboxOutputColors.TabIndex = 49;
             // 
             // aiInfoBtn
@@ -1088,10 +1088,10 @@
             // 
             this.completionActionPanel.Controls.Add(this.completionAction);
             this.completionActionPanel.Controls.Add(this.label25);
-            this.completionActionPanel.Location = new System.Drawing.Point(681, 218);
+            this.completionActionPanel.Location = new System.Drawing.Point(689, 197);
             this.completionActionPanel.Margin = new System.Windows.Forms.Padding(0);
             this.completionActionPanel.Name = "completionActionPanel";
-            this.completionActionPanel.Size = new System.Drawing.Size(220, 40);
+            this.completionActionPanel.Size = new System.Drawing.Size(220, 33);
             this.completionActionPanel.TabIndex = 42;
             // 
             // completionAction
@@ -1108,7 +1108,7 @@
             "Sleep",
             "Hibernate",
             "Shutdown"});
-            this.completionAction.Location = new System.Drawing.Point(84, 11);
+            this.completionAction.Location = new System.Drawing.Point(84, 4);
             this.completionAction.Name = "completionAction";
             this.completionAction.Size = new System.Drawing.Size(130, 23);
             this.completionAction.TabIndex = 40;
@@ -1119,7 +1119,7 @@
             this.label25.AutoSize = true;
             this.label25.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label25.ForeColor = System.Drawing.Color.Silver;
-            this.label25.Location = new System.Drawing.Point(10, 15);
+            this.label25.Location = new System.Drawing.Point(10, 8);
             this.label25.Margin = new System.Windows.Forms.Padding(8, 0, 3, 0);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(68, 13);
@@ -1222,7 +1222,7 @@
             this.quickSettingsTab.Location = new System.Drawing.Point(4, 27);
             this.quickSettingsTab.Name = "quickSettingsTab";
             this.quickSettingsTab.Padding = new System.Windows.Forms.Padding(3);
-            this.quickSettingsTab.Size = new System.Drawing.Size(901, 258);
+            this.quickSettingsTab.Size = new System.Drawing.Size(919, 226);
             this.quickSettingsTab.TabIndex = 1;
             this.quickSettingsTab.Text = "Quick Settings";
             this.quickSettingsTab.Enter += new System.EventHandler(this.LoadQuickSettings);
@@ -1578,7 +1578,7 @@
             this.previewTab.Location = new System.Drawing.Point(4, 27);
             this.previewTab.Margin = new System.Windows.Forms.Padding(0);
             this.previewTab.Name = "previewTab";
-            this.previewTab.Size = new System.Drawing.Size(901, 258);
+            this.previewTab.Size = new System.Drawing.Size(919, 226);
             this.previewTab.TabIndex = 3;
             this.previewTab.Text = "Preview";
             // 
@@ -1602,7 +1602,7 @@
             this.previewPicturebox.Location = new System.Drawing.Point(0, 0);
             this.previewPicturebox.Margin = new System.Windows.Forms.Padding(0);
             this.previewPicturebox.Name = "previewPicturebox";
-            this.previewPicturebox.Size = new System.Drawing.Size(901, 258);
+            this.previewPicturebox.Size = new System.Drawing.Size(919, 226);
             this.previewPicturebox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.previewPicturebox.TabIndex = 0;
             this.previewPicturebox.TabStop = false;
@@ -1615,7 +1615,7 @@
             this.abtTab.Location = new System.Drawing.Point(4, 27);
             this.abtTab.Name = "abtTab";
             this.abtTab.Padding = new System.Windows.Forms.Padding(3);
-            this.abtTab.Size = new System.Drawing.Size(901, 258);
+            this.abtTab.Size = new System.Drawing.Size(919, 226);
             this.abtTab.TabIndex = 2;
             this.abtTab.Text = "About";
             // 
@@ -1630,7 +1630,7 @@
             this.htButton1.ForeColor = System.Drawing.Color.White;
             this.htButton1.ImageIndex = 0;
             this.htButton1.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.htButton1.Location = new System.Drawing.Point(698, 9);
+            this.htButton1.Location = new System.Drawing.Point(698, 6);
             this.htButton1.Name = "htButton1";
             this.htButton1.Size = new System.Drawing.Size(40, 40);
             this.htButton1.TabIndex = 40;
@@ -1642,10 +1642,10 @@
             this.runStepBtn.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(48)))), ((int)(((byte)(48)))), ((int)(((byte)(48)))));
             this.runStepBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.runStepBtn.ForeColor = System.Drawing.Color.White;
-            this.runStepBtn.Location = new System.Drawing.Point(12, 442);
+            this.runStepBtn.Location = new System.Drawing.Point(8, 382);
             this.runStepBtn.Margin = new System.Windows.Forms.Padding(3, 0, 3, 3);
             this.runStepBtn.Name = "runStepBtn";
-            this.runStepBtn.Size = new System.Drawing.Size(203, 47);
+            this.runStepBtn.Size = new System.Drawing.Size(208, 52);
             this.runStepBtn.TabIndex = 42;
             this.runStepBtn.Text = "Run This Step";
             this.runStepBtn.UseVisualStyleBackColor = false;
@@ -1664,52 +1664,36 @@
             "2) Run Interpolation",
             "3) Export",
             "4) Cleanup & Reset"});
-            this.stepSelector.Location = new System.Drawing.Point(12, 418);
+            this.stepSelector.Location = new System.Drawing.Point(8, 357);
             this.stepSelector.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
             this.stepSelector.Name = "stepSelector";
-            this.stepSelector.Size = new System.Drawing.Size(203, 24);
+            this.stepSelector.Size = new System.Drawing.Size(208, 24);
             this.stepSelector.TabIndex = 73;
             // 
             // busyControlsPanel
             // 
             this.busyControlsPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(48)))), ((int)(((byte)(48)))), ((int)(((byte)(48)))));
             this.busyControlsPanel.Controls.Add(this.tableLayoutPanel1);
-            this.busyControlsPanel.Location = new System.Drawing.Point(12, 418);
+            this.busyControlsPanel.Location = new System.Drawing.Point(8, 357);
             this.busyControlsPanel.Name = "busyControlsPanel";
-            this.busyControlsPanel.Size = new System.Drawing.Size(203, 71);
+            this.busyControlsPanel.Size = new System.Drawing.Size(208, 77);
             this.busyControlsPanel.TabIndex = 74;
             this.busyControlsPanel.Visible = false;
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 49F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 51F));
-            this.tableLayoutPanel1.Controls.Add(this.pauseBtn, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.cancelBtn, 0, 0);
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 49.63326F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.36675F));
+            this.tableLayoutPanel1.Controls.Add(this.cancelBtn, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.pauseBtn, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(203, 71);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(208, 77);
             this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // pauseBtn
-            // 
-            this.pauseBtn.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.pauseBtn.BackgroundImage = global::Flowframes.Properties.Resources.baseline_pause_white_48dp;
-            this.pauseBtn.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.pauseBtn.FlatAppearance.MouseOverBackColor = System.Drawing.Color.DarkOrange;
-            this.pauseBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.pauseBtn.ForeColor = System.Drawing.Color.DarkOrange;
-            this.pauseBtn.Location = new System.Drawing.Point(126, 10);
-            this.pauseBtn.Name = "pauseBtn";
-            this.pauseBtn.Size = new System.Drawing.Size(50, 50);
-            this.pauseBtn.TabIndex = 1;
-            this.pauseBtn.UseVisualStyleBackColor = true;
-            this.pauseBtn.Visible = false;
-            this.pauseBtn.Click += new System.EventHandler(this.pauseBtn_Click);
             // 
             // cancelBtn
             // 
@@ -1719,12 +1703,28 @@
             this.cancelBtn.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Firebrick;
             this.cancelBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cancelBtn.ForeColor = System.Drawing.Color.Firebrick;
-            this.cancelBtn.Location = new System.Drawing.Point(24, 10);
+            this.cancelBtn.Location = new System.Drawing.Point(112, 9);
             this.cancelBtn.Name = "cancelBtn";
-            this.cancelBtn.Size = new System.Drawing.Size(50, 50);
+            this.cancelBtn.Size = new System.Drawing.Size(86, 59);
             this.cancelBtn.TabIndex = 0;
             this.cancelBtn.UseVisualStyleBackColor = true;
             this.cancelBtn.Click += new System.EventHandler(this.cancelBtn_Click);
+            // 
+            // pauseBtn
+            // 
+            this.pauseBtn.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.pauseBtn.BackgroundImage = global::Flowframes.Properties.Resources.baseline_pause_white_48dp;
+            this.pauseBtn.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            this.pauseBtn.FlatAppearance.MouseOverBackColor = System.Drawing.Color.DarkOrange;
+            this.pauseBtn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.pauseBtn.ForeColor = System.Drawing.Color.DarkOrange;
+            this.pauseBtn.Location = new System.Drawing.Point(13, 9);
+            this.pauseBtn.Name = "pauseBtn";
+            this.pauseBtn.Size = new System.Drawing.Size(76, 59);
+            this.pauseBtn.TabIndex = 1;
+            this.pauseBtn.UseVisualStyleBackColor = true;
+            this.pauseBtn.Visible = false;
+            this.pauseBtn.Click += new System.EventHandler(this.pauseBtn_Click);
             // 
             // menuStripQueue
             // 
@@ -1740,18 +1740,35 @@
             this.addCurrentConfigurationToQueueToolStripMenuItem.Text = "Add Current Configuration to Queue";
             this.addCurrentConfigurationToQueueToolStripMenuItem.Click += new System.EventHandler(this.addCurrentConfigurationToQueueToolStripMenuItem_Click);
             // 
+            // textBox1
+            // 
+            this.textBox1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.textBox1.Cursor = System.Windows.Forms.Cursors.Arrow;
+            this.textBox1.ForeColor = System.Drawing.Color.White;
+            this.textBox1.Location = new System.Drawing.Point(8, 440);
+            this.textBox1.MinimumSize = new System.Drawing.Size(4, 21);
+            this.textBox1.Multiline = true;
+            this.textBox1.Name = "textBox1";
+            this.textBox1.ReadOnly = true;
+            this.textBox1.Size = new System.Drawing.Size(923, 24);
+            this.textBox1.TabIndex = 76;
+            this.textBox1.TabStop = false;
+            this.textBox1.Text = "  Status: Calculating performance metrics!";
+            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            // 
             // Form1
             // 
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(32)))), ((int)(((byte)(32)))));
-            this.ClientSize = new System.Drawing.Size(934, 501);
+            this.ClientSize = new System.Drawing.Size(934, 466);
+            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.runBtn);
+            this.Controls.Add(this.runStepBtn);
             this.Controls.Add(this.debugBtn);
             this.Controls.Add(this.busyControlsPanel);
-            this.Controls.Add(this.runBtn);
             this.Controls.Add(this.stepSelector);
-            this.Controls.Add(this.runStepBtn);
             this.Controls.Add(this.updateBtn);
             this.Controls.Add(this.htButton1);
             this.Controls.Add(this.queueBtn);
@@ -1919,20 +1936,21 @@
         private System.Windows.Forms.ComboBox outSpeedCombox;
         private System.Windows.Forms.PictureBox pictureBox5;
         private HTAlt.WinForms.HTButton aiInfoBtn;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        public System.Windows.Forms.ComboBox comboxOutputFormat;
-        public System.Windows.Forms.ComboBox comboxOutputColors;
-        public System.Windows.Forms.ComboBox comboxOutputEncoder;
-        public System.Windows.Forms.ComboBox comboxOutputQuality;
         private System.Windows.Forms.Label labelOutput;
         private System.Windows.Forms.ContextMenuStrip menuStripQueue;
         private System.Windows.Forms.ToolStripMenuItem addCurrentConfigurationToQueueToolStripMenuItem;
-        private System.Windows.Forms.TextBox textboxOutputQualityCust;
         public System.Windows.Forms.TabPage interpOptsTab;
         public System.Windows.Forms.TabPage quickSettingsTab;
         public System.Windows.Forms.TabPage abtTab;
         public System.Windows.Forms.TabPage previewTab;
         public System.Windows.Forms.TabPage welcomeTab;
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        public System.Windows.Forms.ComboBox comboxOutputFormat;
+        public System.Windows.Forms.ComboBox comboxOutputEncoder;
+        public System.Windows.Forms.ComboBox comboxOutputQuality;
+        private System.Windows.Forms.TextBox textboxOutputQualityCust;
+        public System.Windows.Forms.ComboBox comboxOutputColors;
     }
 }
 

--- a/Code/Forms/Main/Form1.resx
+++ b/Code/Forms/Main/Form1.resx
@@ -143,6 +143,9 @@ Based on:
   <metadata name="menuStripQueue.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>500, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Code/Forms/SettingsForm.Designer.cs
+++ b/Code/Forms/SettingsForm.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Flowframes.Forms
+﻿using Flowframes.IO;
+
+namespace Flowframes.Forms
 {
     partial class SettingsForm
     {
@@ -61,6 +63,13 @@
             this.maxVidHeight = new System.Windows.Forms.ComboBox();
             this.label31 = new System.Windows.Forms.Label();
             this.tabListPage2 = new Cyotek.Windows.Forms.TabListPage();
+            this.label13 = new System.Windows.Forms.Label();
+            this.intelQSVDecode = new System.Windows.Forms.CheckBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.mpdecimateMode = new System.Windows.Forms.ComboBox();
+            this.formatofInterp = new System.Windows.Forms.ComboBox();
+            this.label11 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
             this.autoEncBlockPanel = new System.Windows.Forms.Panel();
             this.label70 = new System.Windows.Forms.Label();
             this.alwaysWaitForAutoEnc = new System.Windows.Forms.CheckBox();
@@ -92,9 +101,8 @@
             this.scnDetect = new System.Windows.Forms.CheckBox();
             this.label50 = new System.Windows.Forms.Label();
             this.mpDedupePanel = new System.Windows.Forms.Panel();
-            this.mpdecimateMode = new System.Windows.Forms.ComboBox();
-            this.magickDedupePanel = new System.Windows.Forms.Panel();
             this.dedupThresh = new System.Windows.Forms.NumericUpDown();
+            this.magickDedupePanel = new System.Windows.Forms.Panel();
             this.panel3 = new System.Windows.Forms.Panel();
             this.label24 = new System.Windows.Forms.Label();
             this.enableLoop = new System.Windows.Forms.CheckBox();
@@ -164,8 +172,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.scnDetectValue)).BeginInit();
             this.mpDedupePanel.SuspendLayout();
-            this.magickDedupePanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dedupThresh)).BeginInit();
+            this.magickDedupePanel.SuspendLayout();
             this.aiOptsPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ncnnThreads)).BeginInit();
             this.vidExportTab.SuspendLayout();
@@ -185,9 +193,9 @@
             this.settingsTabList.Controls.Add(this.vidExportTab);
             this.settingsTabList.Controls.Add(this.debugTab);
             this.settingsTabList.ForeColor = System.Drawing.Color.DodgerBlue;
-            this.settingsTabList.Location = new System.Drawing.Point(12, 62);
+            this.settingsTabList.Location = new System.Drawing.Point(12, 40);
             this.settingsTabList.Name = "settingsTabList";
-            this.settingsTabList.Size = new System.Drawing.Size(920, 427);
+            this.settingsTabList.Size = new System.Drawing.Size(920, 520);
             this.settingsTabList.TabIndex = 0;
             // 
             // generalTab
@@ -223,7 +231,7 @@
             this.generalTab.Controls.Add(this.label31);
             this.generalTab.ForeColor = System.Drawing.Color.White;
             this.generalTab.Name = "generalTab";
-            this.generalTab.Size = new System.Drawing.Size(762, 419);
+            this.generalTab.Size = new System.Drawing.Size(762, 512);
             this.generalTab.Text = "Application";
             // 
             // custOutDirBrowseBtn
@@ -493,6 +501,7 @@
             "Parent Directory Of Output Folder",
             "Inside Output Folder",
             "Flowframes Program Folder",
+            "Windows Temp Folder",
             "Custom..."});
             this.tempFolderLoc.Location = new System.Drawing.Point(280, 67);
             this.tempFolderLoc.Name = "tempFolderLoc";
@@ -554,6 +563,13 @@
             // tabListPage2
             // 
             this.tabListPage2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(48)))), ((int)(((byte)(48)))), ((int)(((byte)(48)))));
+            this.tabListPage2.Controls.Add(this.label13);
+            this.tabListPage2.Controls.Add(this.intelQSVDecode);
+            this.tabListPage2.Controls.Add(this.label12);
+            this.tabListPage2.Controls.Add(this.mpdecimateMode);
+            this.tabListPage2.Controls.Add(this.formatofInterp);
+            this.tabListPage2.Controls.Add(this.label11);
+            this.tabListPage2.Controls.Add(this.label10);
             this.tabListPage2.Controls.Add(this.autoEncBlockPanel);
             this.tabListPage2.Controls.Add(this.label70);
             this.tabListPage2.Controls.Add(this.alwaysWaitForAutoEnc);
@@ -595,21 +611,118 @@
             this.tabListPage2.Controls.Add(this.label1);
             this.tabListPage2.ForeColor = System.Drawing.Color.White;
             this.tabListPage2.Name = "tabListPage2";
-            this.tabListPage2.Size = new System.Drawing.Size(762, 419);
+            this.tabListPage2.Size = new System.Drawing.Size(762, 512);
             this.tabListPage2.Text = "Interpolation";
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.ForeColor = System.Drawing.Color.Silver;
+            this.label13.Location = new System.Drawing.Point(356, 166);
+            this.label13.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(389, 13);
+            this.label13.TabIndex = 101;
+            this.label13.Text = "Intel QSV Image Extractor. This will always generate JPEG always. (Experiemntal)";
+            this.label13.Click += new System.EventHandler(this.label13_Click);
+            // 
+            // intelQSVDecode
+            // 
+            this.intelQSVDecode.AutoSize = true;
+            this.intelQSVDecode.Location = new System.Drawing.Point(280, 165);
+            this.intelQSVDecode.Name = "intelQSVDecode";
+            this.intelQSVDecode.Size = new System.Drawing.Size(15, 14);
+            this.intelQSVDecode.TabIndex = 100;
+            this.intelQSVDecode.UseVisualStyleBackColor = true;
+            this.intelQSVDecode.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.Location = new System.Drawing.Point(10, 165);
+            this.label12.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(93, 13);
+            this.label12.TabIndex = 99;
+            this.label12.Text = "Intel QSV Decode";
+            this.label12.Click += new System.EventHandler(this.label12_Click);
+            // 
+            // mpdecimateMode
+            // 
+            this.mpdecimateMode.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.mpdecimateMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.mpdecimateMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.mpdecimateMode.ForeColor = System.Drawing.Color.White;
+            this.mpdecimateMode.FormattingEnabled = true;
+            this.mpdecimateMode.Items.AddRange(new object[] {
+            "Normal",
+            "Aggressive"});
+            this.mpdecimateMode.Location = new System.Drawing.Point(599, 218);
+            this.mpdecimateMode.Margin = new System.Windows.Forms.Padding(3, 3, 8, 3);
+            this.mpdecimateMode.Name = "mpdecimateMode";
+            this.mpdecimateMode.Size = new System.Drawing.Size(135, 21);
+            this.mpdecimateMode.TabIndex = 28;
+            // 
+            // formatofInterp
+            // 
+            this.formatofInterp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.formatofInterp.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.formatofInterp.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.formatofInterp.ForeColor = System.Drawing.Color.White;
+            this.formatofInterp.FormattingEnabled = true;
+            this.formatofInterp.Items.AddRange(new object[] {
+            "jpg",
+            "png"});
+            this.formatofInterp.Location = new System.Drawing.Point(280, 132);
+            this.formatofInterp.Name = "formatofInterp";
+            this.formatofInterp.Size = new System.Drawing.Size(61, 21);
+            this.formatofInterp.TabIndex = 98;
+
+            if (Config.GetString(Config.Key.formatofInterp) == "png") {
+            this.formatofInterp.SelectedIndex = 1;
+            }
+            else {
+            this.formatofInterp.SelectedIndex = 0;
+            }
+
+            this.formatofInterp.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.ForeColor = System.Drawing.Color.Silver;
+            this.label11.Location = new System.Drawing.Point(354, 135);
+            this.label11.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(252, 13);
+            this.label11.TabIndex = 97;
+            this.label11.Text = "JPG/PNG Images. JPEG vs PNG (Faster vs Quality)";
+            this.label11.Click += new System.EventHandler(this.label11_Click);
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(10, 135);
+            this.label10.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(135, 13);
+            this.label10.TabIndex = 95;
+            this.label10.Text = "Interpolated Frames Format";
+            this.label10.Click += new System.EventHandler(this.label10_Click);
             // 
             // autoEncBlockPanel
             // 
-            this.autoEncBlockPanel.Location = new System.Drawing.Point(4, 330);
+            this.autoEncBlockPanel.Location = new System.Drawing.Point(4, 455);
             this.autoEncBlockPanel.Name = "autoEncBlockPanel";
-            this.autoEncBlockPanel.Size = new System.Drawing.Size(755, 86);
+            this.autoEncBlockPanel.Size = new System.Drawing.Size(755, 42);
             this.autoEncBlockPanel.TabIndex = 94;
+            this.autoEncBlockPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.autoEncBlockPanel_Paint);
             // 
             // label70
             // 
             this.label70.AutoSize = true;
             this.label70.ForeColor = System.Drawing.Color.Silver;
-            this.label70.Location = new System.Drawing.Point(308, 390);
+            this.label70.Location = new System.Drawing.Point(309, 432);
             this.label70.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label70.Name = "label70";
             this.label70.Size = new System.Drawing.Size(443, 13);
@@ -620,7 +733,7 @@
             // alwaysWaitForAutoEnc
             // 
             this.alwaysWaitForAutoEnc.AutoSize = true;
-            this.alwaysWaitForAutoEnc.Location = new System.Drawing.Point(280, 390);
+            this.alwaysWaitForAutoEnc.Location = new System.Drawing.Point(281, 431);
             this.alwaysWaitForAutoEnc.Name = "alwaysWaitForAutoEnc";
             this.alwaysWaitForAutoEnc.Size = new System.Drawing.Size(15, 14);
             this.alwaysWaitForAutoEnc.TabIndex = 92;
@@ -629,7 +742,7 @@
             // label58
             // 
             this.label58.AutoSize = true;
-            this.label58.Location = new System.Drawing.Point(10, 390);
+            this.label58.Location = new System.Drawing.Point(10, 431);
             this.label58.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label58.Name = "label58";
             this.label58.Size = new System.Drawing.Size(229, 13);
@@ -640,7 +753,7 @@
             // 
             this.pictureBox2.BackgroundImage = global::Flowframes.Properties.Resources.questmark_72px_bordeer;
             this.pictureBox2.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.pictureBox2.Location = new System.Drawing.Point(536, 357);
+            this.pictureBox2.Location = new System.Drawing.Point(548, 393);
             this.pictureBox2.Name = "pictureBox2";
             this.pictureBox2.Size = new System.Drawing.Size(29, 21);
             this.pictureBox2.TabIndex = 90;
@@ -651,7 +764,7 @@
             // 
             this.label41.AutoSize = true;
             this.label41.ForeColor = System.Drawing.Color.Silver;
-            this.label41.Location = new System.Drawing.Point(578, 360);
+            this.label41.Location = new System.Drawing.Point(590, 401);
             this.label41.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label41.Name = "label41";
             this.label41.Size = new System.Drawing.Size(158, 13);
@@ -669,7 +782,7 @@
             "Disabled",
             "Enabled (Only Video)",
             "Enabled (Complete - With Audio, Subtitles)"});
-            this.autoEncBackupMode.Location = new System.Drawing.Point(280, 357);
+            this.autoEncBackupMode.Location = new System.Drawing.Point(281, 393);
             this.autoEncBackupMode.Name = "autoEncBackupMode";
             this.autoEncBackupMode.Size = new System.Drawing.Size(250, 21);
             this.autoEncBackupMode.TabIndex = 88;
@@ -677,7 +790,7 @@
             // label16
             // 
             this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(10, 360);
+            this.label16.Location = new System.Drawing.Point(10, 401);
             this.label16.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label16.Name = "label16";
             this.label16.Size = new System.Drawing.Size(114, 13);
@@ -714,12 +827,13 @@
             this.label63.Size = new System.Drawing.Size(170, 13);
             this.label63.TabIndex = 84;
             this.label63.Text = "Import HQ JPEGs instead of PNGs";
+            this.label63.Click += new System.EventHandler(this.label63_Click);
             // 
             // label18
             // 
             this.label18.AutoSize = true;
             this.label18.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label18.Location = new System.Drawing.Point(10, 150);
+            this.label18.Location = new System.Drawing.Point(10, 193);
             this.label18.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(152, 16);
@@ -746,7 +860,7 @@
             this.sceneChangeFillMode.Items.AddRange(new object[] {
             "Basic (Duplicate Previous Frame)",
             "Fancy (Blend To Next Scene)"});
-            this.sceneChangeFillMode.Location = new System.Drawing.Point(280, 267);
+            this.sceneChangeFillMode.Location = new System.Drawing.Point(281, 308);
             this.sceneChangeFillMode.Name = "sceneChangeFillMode";
             this.sceneChangeFillMode.Size = new System.Drawing.Size(250, 21);
             this.sceneChangeFillMode.TabIndex = 80;
@@ -754,7 +868,7 @@
             // label71
             // 
             this.label71.AutoSize = true;
-            this.label71.Location = new System.Drawing.Point(10, 270);
+            this.label71.Location = new System.Drawing.Point(10, 316);
             this.label71.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label71.Name = "label71";
             this.label71.Size = new System.Drawing.Size(124, 13);
@@ -811,7 +925,7 @@
             0,
             0,
             131072});
-            this.scnDetectValue.Location = new System.Drawing.Point(364, 238);
+            this.scnDetectValue.Location = new System.Drawing.Point(364, 283);
             this.scnDetectValue.Maximum = new decimal(new int[] {
             5,
             0,
@@ -834,7 +948,7 @@
             // sbsAllowAutoEnc
             // 
             this.sbsAllowAutoEnc.AutoSize = true;
-            this.sbsAllowAutoEnc.Location = new System.Drawing.Point(280, 330);
+            this.sbsAllowAutoEnc.Location = new System.Drawing.Point(281, 370);
             this.sbsAllowAutoEnc.Name = "sbsAllowAutoEnc";
             this.sbsAllowAutoEnc.Size = new System.Drawing.Size(15, 14);
             this.sbsAllowAutoEnc.TabIndex = 72;
@@ -843,7 +957,7 @@
             // dedupeSensLabel
             // 
             this.dedupeSensLabel.AutoSize = true;
-            this.dedupeSensLabel.Location = new System.Drawing.Point(536, 181);
+            this.dedupeSensLabel.Location = new System.Drawing.Point(536, 226);
             this.dedupeSensLabel.Margin = new System.Windows.Forms.Padding(3);
             this.dedupeSensLabel.Name = "dedupeSensLabel";
             this.dedupeSensLabel.Size = new System.Drawing.Size(57, 13);
@@ -853,7 +967,7 @@
             // label53
             // 
             this.label53.AutoSize = true;
-            this.label53.Location = new System.Drawing.Point(10, 330);
+            this.label53.Location = new System.Drawing.Point(10, 371);
             this.label53.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label53.Name = "label53";
             this.label53.Size = new System.Drawing.Size(203, 13);
@@ -871,7 +985,7 @@
             "Disabled",
             "Enabled (Keep Interpolated Frames)",
             "Enabled (Delete Frames Once Encoded)"});
-            this.autoEncMode.Location = new System.Drawing.Point(280, 297);
+            this.autoEncMode.Location = new System.Drawing.Point(281, 338);
             this.autoEncMode.Name = "autoEncMode";
             this.autoEncMode.Size = new System.Drawing.Size(250, 21);
             this.autoEncMode.TabIndex = 70;
@@ -880,7 +994,7 @@
             // label49
             // 
             this.label49.AutoSize = true;
-            this.label49.Location = new System.Drawing.Point(10, 300);
+            this.label49.Location = new System.Drawing.Point(10, 341);
             this.label49.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label49.Name = "label49";
             this.label49.Size = new System.Drawing.Size(206, 13);
@@ -891,7 +1005,7 @@
             // 
             this.panel14.BackgroundImage = global::Flowframes.Properties.Resources.baseline_create_white_18dp_semiTransparent;
             this.panel14.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.panel14.Location = new System.Drawing.Point(475, 237);
+            this.panel14.Location = new System.Drawing.Point(482, 282);
             this.panel14.Name = "panel14";
             this.panel14.Size = new System.Drawing.Size(21, 21);
             this.panel14.TabIndex = 68;
@@ -901,7 +1015,7 @@
             // 
             this.label52.AutoSize = true;
             this.label52.ForeColor = System.Drawing.Color.Silver;
-            this.label52.Location = new System.Drawing.Point(509, 242);
+            this.label52.Location = new System.Drawing.Point(516, 285);
             this.label52.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label52.Name = "label52";
             this.label52.Size = new System.Drawing.Size(225, 13);
@@ -911,7 +1025,7 @@
             // label51
             // 
             this.label51.AutoSize = true;
-            this.label51.Location = new System.Drawing.Point(301, 241);
+            this.label51.Location = new System.Drawing.Point(301, 284);
             this.label51.Margin = new System.Windows.Forms.Padding(3);
             this.label51.Name = "label51";
             this.label51.Size = new System.Drawing.Size(57, 13);
@@ -921,7 +1035,7 @@
             // scnDetect
             // 
             this.scnDetect.AutoSize = true;
-            this.scnDetect.Location = new System.Drawing.Point(280, 240);
+            this.scnDetect.Location = new System.Drawing.Point(280, 284);
             this.scnDetect.Name = "scnDetect";
             this.scnDetect.Size = new System.Drawing.Size(15, 14);
             this.scnDetect.TabIndex = 64;
@@ -930,7 +1044,7 @@
             // label50
             // 
             this.label50.AutoSize = true;
-            this.label50.Location = new System.Drawing.Point(10, 240);
+            this.label50.Location = new System.Drawing.Point(10, 286);
             this.label50.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(129, 13);
@@ -939,38 +1053,12 @@
             // 
             // mpDedupePanel
             // 
-            this.mpDedupePanel.Controls.Add(this.mpdecimateMode);
-            this.mpDedupePanel.Location = new System.Drawing.Point(599, 177);
+            this.mpDedupePanel.Controls.Add(this.dedupThresh);
+            this.mpDedupePanel.Location = new System.Drawing.Point(599, 218);
             this.mpDedupePanel.Margin = new System.Windows.Forms.Padding(0);
             this.mpDedupePanel.Name = "mpDedupePanel";
             this.mpDedupePanel.Size = new System.Drawing.Size(135, 21);
             this.mpDedupePanel.TabIndex = 61;
-            // 
-            // mpdecimateMode
-            // 
-            this.mpdecimateMode.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.mpdecimateMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.mpdecimateMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.mpdecimateMode.ForeColor = System.Drawing.Color.White;
-            this.mpdecimateMode.FormattingEnabled = true;
-            this.mpdecimateMode.Items.AddRange(new object[] {
-            "Normal",
-            "Aggressive"});
-            this.mpdecimateMode.Location = new System.Drawing.Point(0, 0);
-            this.mpdecimateMode.Margin = new System.Windows.Forms.Padding(3, 3, 8, 3);
-            this.mpdecimateMode.Name = "mpdecimateMode";
-            this.mpdecimateMode.Size = new System.Drawing.Size(135, 21);
-            this.mpdecimateMode.TabIndex = 28;
-            // 
-            // magickDedupePanel
-            // 
-            this.magickDedupePanel.Controls.Add(this.dedupThresh);
-            this.magickDedupePanel.Controls.Add(this.panel3);
-            this.magickDedupePanel.Location = new System.Drawing.Point(599, 177);
-            this.magickDedupePanel.Margin = new System.Windows.Forms.Padding(0);
-            this.magickDedupePanel.Name = "magickDedupePanel";
-            this.magickDedupePanel.Size = new System.Drawing.Size(135, 21);
-            this.magickDedupePanel.TabIndex = 60;
             // 
             // dedupThresh
             // 
@@ -1003,6 +1091,15 @@
             0,
             65536});
             // 
+            // magickDedupePanel
+            // 
+            this.magickDedupePanel.Controls.Add(this.panel3);
+            this.magickDedupePanel.Location = new System.Drawing.Point(599, 218);
+            this.magickDedupePanel.Margin = new System.Windows.Forms.Padding(0);
+            this.magickDedupePanel.Name = "magickDedupePanel";
+            this.magickDedupePanel.Size = new System.Drawing.Size(135, 21);
+            this.magickDedupePanel.TabIndex = 60;
+            // 
             // panel3
             // 
             this.panel3.BackgroundImage = global::Flowframes.Properties.Resources.baseline_create_white_18dp_semiTransparent;
@@ -1027,7 +1124,7 @@
             // enableLoop
             // 
             this.enableLoop.AutoSize = true;
-            this.enableLoop.Location = new System.Drawing.Point(280, 210);
+            this.enableLoop.Location = new System.Drawing.Point(280, 256);
             this.enableLoop.Name = "enableLoop";
             this.enableLoop.Size = new System.Drawing.Size(15, 14);
             this.enableLoop.TabIndex = 31;
@@ -1036,7 +1133,7 @@
             // label15
             // 
             this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(10, 210);
+            this.label15.Location = new System.Drawing.Point(10, 256);
             this.label15.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label15.Name = "label15";
             this.label15.Size = new System.Drawing.Size(217, 13);
@@ -1045,6 +1142,7 @@
             // 
             // dedupMode
             // 
+            this.dedupMode.AccessibleRole = System.Windows.Forms.AccessibleRole.OutlineButton;
             this.dedupMode.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.dedupMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.dedupMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
@@ -1054,7 +1152,7 @@
             "Disabled",
             "1: After Extraction - Slow, Accurate",
             "2: During Extraction - Fast, Less Accurate"});
-            this.dedupMode.Location = new System.Drawing.Point(280, 177);
+            this.dedupMode.Location = new System.Drawing.Point(280, 218);
             this.dedupMode.Name = "dedupMode";
             this.dedupMode.Size = new System.Drawing.Size(250, 21);
             this.dedupMode.TabIndex = 27;
@@ -1063,7 +1161,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 180);
+            this.label2.Location = new System.Drawing.Point(10, 226);
             this.label2.Margin = new System.Windows.Forms.Padding(10, 10, 10, 7);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(139, 13);
@@ -1118,7 +1216,7 @@
             this.aiOptsPage.Controls.Add(this.label32);
             this.aiOptsPage.ForeColor = System.Drawing.Color.White;
             this.aiOptsPage.Name = "aiOptsPage";
-            this.aiOptsPage.Size = new System.Drawing.Size(762, 419);
+            this.aiOptsPage.Size = new System.Drawing.Size(762, 512);
             this.aiOptsPage.Text = "AI Specific Options";
             // 
             // label66
@@ -1420,7 +1518,7 @@
             this.vidExportTab.Controls.Add(this.label8);
             this.vidExportTab.ForeColor = System.Drawing.Color.White;
             this.vidExportTab.Name = "vidExportTab";
-            this.vidExportTab.Size = new System.Drawing.Size(762, 419);
+            this.vidExportTab.Size = new System.Drawing.Size(762, 512);
             this.vidExportTab.Text = "Export Options";
             // 
             // label73
@@ -1602,7 +1700,7 @@
             this.debugTab.Controls.Add(this.cmdDebugMode);
             this.debugTab.ForeColor = System.Drawing.Color.White;
             this.debugTab.Name = "debugTab";
-            this.debugTab.Size = new System.Drawing.Size(762, 419);
+            this.debugTab.Size = new System.Drawing.Size(762, 512);
             this.debugTab.Text = "Developer Options";
             // 
             // label7
@@ -1748,14 +1846,15 @@
             // titleLabel
             // 
             this.titleLabel.AutoSize = true;
-            this.titleLabel.Font = new System.Drawing.Font("Yu Gothic UI", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.titleLabel.Font = new System.Drawing.Font("Yu Gothic UI", 15.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.titleLabel.ForeColor = System.Drawing.Color.White;
-            this.titleLabel.Location = new System.Drawing.Point(12, 9);
+            this.titleLabel.Location = new System.Drawing.Point(12, 5);
             this.titleLabel.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
             this.titleLabel.Name = "titleLabel";
-            this.titleLabel.Size = new System.Drawing.Size(119, 40);
+            this.titleLabel.Size = new System.Drawing.Size(87, 30);
             this.titleLabel.TabIndex = 1;
             this.titleLabel.Text = "Settings";
+            this.titleLabel.Click += new System.EventHandler(this.titleLabel_Click);
             // 
             // resetBtn
             // 
@@ -1767,9 +1866,9 @@
             this.resetBtn.ForeColor = System.Drawing.Color.White;
             this.resetBtn.ImageIndex = 0;
             this.resetBtn.ImageSizeMode = HTAlt.WinForms.HTButton.ButtonImageSizeMode.Zoom;
-            this.resetBtn.Location = new System.Drawing.Point(889, 12);
+            this.resetBtn.Location = new System.Drawing.Point(896, 5);
             this.resetBtn.Name = "resetBtn";
-            this.resetBtn.Size = new System.Drawing.Size(40, 40);
+            this.resetBtn.Size = new System.Drawing.Size(36, 33);
             this.resetBtn.TabIndex = 39;
             this.toolTip1.SetToolTip(this.resetBtn, "Reset To Default");
             this.resetBtn.UseVisualStyleBackColor = false;
@@ -1780,7 +1879,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(32)))), ((int)(((byte)(32)))));
-            this.ClientSize = new System.Drawing.Size(944, 501);
+            this.ClientSize = new System.Drawing.Size(944, 572);
             this.Controls.Add(this.resetBtn);
             this.Controls.Add(this.titleLabel);
             this.Controls.Add(this.settingsTabList);
@@ -1801,8 +1900,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.scnDetectValue)).EndInit();
             this.mpDedupePanel.ResumeLayout(false);
-            this.magickDedupePanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dedupThresh)).EndInit();
+            this.magickDedupePanel.ResumeLayout(false);
             this.aiOptsPage.ResumeLayout(false);
             this.aiOptsPage.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.ncnnThreads)).EndInit();
@@ -1820,7 +1919,6 @@
 
         private Cyotek.Windows.Forms.TabList settingsTabList;
         private Cyotek.Windows.Forms.TabListPage generalTab;
-        private Cyotek.Windows.Forms.TabListPage tabListPage2;
         private Cyotek.Windows.Forms.TabListPage debugTab;
         private System.Windows.Forms.Label titleLabel;
         private System.Windows.Forms.Label label2;
@@ -1848,7 +1946,6 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label32;
         private System.Windows.Forms.Panel panel2;
-        private System.Windows.Forms.Panel panel3;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.Panel panel8;
         private System.Windows.Forms.Panel panel7;
@@ -1864,9 +1961,7 @@
         private HTAlt.WinForms.HTButton tempDirBrowseBtn;
         private System.Windows.Forms.ComboBox processingMode;
         private System.Windows.Forms.Label label39;
-        private System.Windows.Forms.Panel mpDedupePanel;
         private System.Windows.Forms.ComboBox mpdecimateMode;
-        private System.Windows.Forms.Panel magickDedupePanel;
         private System.Windows.Forms.Label label44;
         private System.Windows.Forms.Label label43;
         private System.Windows.Forms.ComboBox ffEncPreset;
@@ -1895,7 +1990,6 @@
         private System.Windows.Forms.Label label64;
         private HTAlt.WinForms.HTButton clearModelCacheBtn;
         private System.Windows.Forms.NumericUpDown scnDetectValue;
-        private System.Windows.Forms.NumericUpDown dedupThresh;
         private System.Windows.Forms.NumericUpDown ncnnThreads;
         private System.Windows.Forms.NumericUpDown minOutVidLength;
         private System.Windows.Forms.CheckBox keepSubs;
@@ -1945,5 +2039,16 @@
         private System.Windows.Forms.Label label78;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.ComboBox serverCombox;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.ComboBox formatofInterp;
+        protected Cyotek.Windows.Forms.TabListPage tabListPage2;
+        private System.Windows.Forms.Panel mpDedupePanel;
+        private System.Windows.Forms.NumericUpDown dedupThresh;
+        private System.Windows.Forms.Panel magickDedupePanel;
+        private System.Windows.Forms.Panel panel3;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.CheckBox intelQSVDecode;
     }
 }

--- a/Code/Forms/SettingsForm.cs
+++ b/Code/Forms/SettingsForm.cs
@@ -5,6 +5,8 @@ using Flowframes.MiscUtils;
 using Flowframes.Ui;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -94,6 +96,8 @@ namespace Flowframes.Forms
             ConfigParser.SaveGuiElement(keepMeta);
             ConfigParser.SaveGuiElement(enableAlpha);
             ConfigParser.SaveGuiElement(jpegFrames);
+            ConfigParser.SaveGuiElement(formatofInterp);
+            ConfigParser.SaveGuiElement(intelQSVDecode);
             ConfigParser.SaveComboxIndex(dedupMode);
             ConfigParser.SaveComboxIndex(mpdecimateMode);
             ConfigParser.SaveGuiElement(dedupThresh);
@@ -141,6 +145,8 @@ namespace Flowframes.Forms
             ConfigParser.LoadGuiElement(keepMeta);
             ConfigParser.LoadGuiElement(enableAlpha);
             ConfigParser.LoadGuiElement(jpegFrames);
+            ConfigParser.SaveGuiElement(formatofInterp);
+            ConfigParser.LoadGuiElement(intelQSVDecode);
             ConfigParser.LoadComboxIndex(dedupMode);
             ConfigParser.LoadComboxIndex(mpdecimateMode);
             ConfigParser.LoadGuiElement(dedupThresh);
@@ -173,8 +179,8 @@ namespace Flowframes.Forms
 
         private void tempFolderLoc_SelectedIndexChanged(object sender, EventArgs e)
         {
-            tempDirBrowseBtn.Visible = tempFolderLoc.SelectedIndex == 4;
-            tempDirCustom.Visible = tempFolderLoc.SelectedIndex == 4;
+            tempDirBrowseBtn.Visible = tempFolderLoc.SelectedIndex == 5;
+            tempDirCustom.Visible = tempFolderLoc.SelectedIndex == 5;
         }
 
         private void outFolderLoc_SelectedIndexChanged(object sender, EventArgs e)
@@ -243,6 +249,53 @@ namespace Flowframes.Forms
 
             await Config.Reset(3, this);
             SettingsForm_Load(null, null);
+        }
+
+        private void label63_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void label10_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void label11_Click(object sender, EventArgs e)
+        {
+
+        }
+
+
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+           
+        }
+
+        private void autoEncBlockPanel_Paint(object sender, PaintEventArgs e)
+        {
+
+        }
+
+        private void label12_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void label13_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void titleLabel_Click(object sender, EventArgs e)
+        {
+
+        }
+
+
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            
         }
     }
 }

--- a/Code/Forms/SettingsForm.resx
+++ b/Code/Forms/SettingsForm.resx
@@ -140,6 +140,9 @@ The loop suffix gets added if the output gets looped. You can use the following 
     <value>If this is enabled together with Auto-Encode, a backup video will be created from already encoded chunks, after each chunk has finished encoding.
 This causes a minimal CPU load but requires lots of storage bandwidth - It's only recommended to use this on SSDs for longer videos.</value>
   </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Code/IO/Config.cs
+++ b/Code/IO/Config.cs
@@ -164,6 +164,11 @@ namespace Flowframes.IO
             return Get(key, Type.Int).GetInt();
         }
 
+        public static String GetString(Key key)
+        {
+            return Get(key, Type.String).ToString();
+        }
+
         public static int GetInt(Key key, int defaultVal)
         {
             WriteIfDoesntExist(key.ToString(), defaultVal.ToString());
@@ -244,6 +249,7 @@ namespace Flowframes.IO
             if (key == Key.disablePreview)        return WriteDefault(key, "True");
             if (key == Key.maxVidHeight)          return WriteDefault(key, "2160");
             if (key == Key.clearLogOnInput)       return WriteDefault(key, "True");
+            if (key == Key.tempFolderLoc)         return WriteDefault(key, "4");
             if (key == Key.tempDirCustom)         return WriteDefault(key, "D:/");
             if (key == Key.exportNamePattern)     return WriteDefault(key, "[NAME]-[FACTOR]x-[AI]-[MODEL]-[FPS]fps");
             if (key == Key.exportNamePatternLoop) return WriteDefault(key, "-Loop[LOOPS]");
@@ -256,11 +262,18 @@ namespace Flowframes.IO
             if (key == Key.scnDetectValue)        return WriteDefault(key, "0.2");
             if (key == Key.sceneChangeFillMode)   return WriteDefault(key, "1");
             if (key == Key.autoEncMode)           return WriteDefault(key, "2");
+            if (key == Key.intelQSVDecode)        return WriteDefault(key, "False");
             if (key == Key.jpegFrames)            return WriteDefault(key, "True");
+            if (key == Key.formatofInterp)        return WriteDefault(key, "png");
+            if (key == Key.lastUsedAiName)       return WriteDefault(key, "RIFE_CUDA");
+
+            
+
             // Video Export
-            if (key == Key.minOutVidLength)   return WriteDefault(key, "5");
-            if (key == Key.gifDitherType)     return WriteDefault(key, "bayer");
-            if (key == Key.minVidLength)      return WriteDefault(key, "5");
+            if (key == Key.minOutVidLength)     return WriteDefault(key, "5");
+            if (key == Key.gifDitherType)       return WriteDefault(key, "bayer");
+            if (key == Key.minVidLength)        return WriteDefault(key, "5");
+
             // AI
             if (key == Key.uhdThresh)         return WriteDefault(key, "1600");
             if (key == Key.torchGpus)         return WriteDefault(key, "0");
@@ -325,7 +338,8 @@ namespace Flowframes.IO
             gifDitherType,
             imgSeqSampleCount,
             jpegFrames,
-            jpegInterp,
+            formatofInterp,
+            intelQSVDecode,
             keepAspectRatio,
             keepAudio,
             keepColorSpace,

--- a/Code/IO/Logger.cs
+++ b/Code/IO/Logger.cs
@@ -3,10 +3,16 @@ using Flowframes.Ui;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Management.Instrumentation;
+using System.Reflection;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Xml.Linq;
 using DT = System.DateTime;
 
 namespace Flowframes
@@ -40,7 +46,10 @@ namespace Flowframes
             }
         }
 
+
         private static ConcurrentQueue<LogEntry> logQueue = new ConcurrentQueue<LogEntry>();
+
+
 
         public static void Log(string msg, bool hidden = false, bool replaceLastLine = false, string filename = "")
         {
@@ -101,30 +110,33 @@ namespace Flowframes
             LogToFile(msg, false, entry.filename);
         }
 
-        public static void LogToFile(string logStr, bool noLineBreak, string filename)
-        {
-            if (string.IsNullOrWhiteSpace(filename))
-                filename = defaultLogName;
 
-            if (Path.GetExtension(filename) != ".txt")
-                filename = Path.ChangeExtension(filename, "txt");
+                public static void LogToFile(string logStr, bool noLineBreak, string filename)
+                {
+                    if (string.IsNullOrWhiteSpace(filename))
+                        filename = defaultLogName;
 
-            file = Path.Combine(Paths.GetLogPath(), filename);
-            logStr = logStr.Replace(Environment.NewLine, " ").TrimWhitespaces();
-            string time = DateTime.Now.ToString("MM-dd-yyyy HH:mm:ss");
+                    if (Path.GetExtension(filename) != ".txt")
+                        filename = Path.ChangeExtension(filename, "txt");
 
-            try
-            {
-                string appendStr = noLineBreak ? $" {logStr}" : $"{Environment.NewLine}[{id.ToString().PadLeft(8, '0')}] [{time}]: {logStr}";
-                sessionLogs[filename] = (sessionLogs.ContainsKey(filename) ? sessionLogs[filename] : "") + appendStr;
-                File.AppendAllText(file, appendStr);
-                id++;
-            }
-            catch
-            {
-                // this if fine, i forgot why
-            }
-        }
+                    file = Path.Combine(Paths.GetLogPath(), filename);
+                    logStr = logStr.Replace(Environment.NewLine, " ").TrimWhitespaces();
+                    string time = DateTime.Now.ToString("MM-dd-yyyy HH:mm:ss");
+
+                     try
+                     {
+                      string appendStr = noLineBreak ? $" {logStr}" : $"{Environment.NewLine}[{id.ToString().PadLeft(8, '0')}] [{time}]: {logStr}";
+                      sessionLogs[filename] = (sessionLogs.ContainsKey(filename) ? sessionLogs[filename] : "") + appendStr;
+                      File.AppendAllText(file, appendStr);
+                      id++;
+                      }
+
+                    catch
+                    {
+                        // this if fine, i forgot why
+                    }
+                }
+
 
         public static string GetSessionLog(string filename)
         {
@@ -137,12 +149,15 @@ namespace Flowframes
                 return "";
         }
 
-        public static List<string> GetSessionLogLastLines(string filename, int linesCount = 5)
-        {
-            string log = GetSessionLog(filename);
-            string[] lines = log.SplitIntoLines();
-            return lines.Reverse().Take(linesCount).Reverse().ToList();
-        }
+
+                public static List<string> GetSessionLogLastLines(string filename, int linesCount = 5)
+                {
+                    string log = GetSessionLog(filename);
+                    string[] lines = log.SplitIntoLines();
+                    return lines.Reverse().Take(linesCount).Reverse().ToList();
+                }
+
+
 
         public static void LogIfLastLineDoesNotContainMsg(string s, bool hidden = false, bool replaceLastLine = false, string filename = "")
         {

--- a/Code/IO/TSource.cs
+++ b/Code/IO/TSource.cs
@@ -1,0 +1,6 @@
+﻿namespace Flowframes
+{
+    internal class TSource
+    {
+    }
+}

--- a/Code/Magick/Blend.cs
+++ b/Code/Magick/Blend.cs
@@ -123,7 +123,20 @@ namespace Flowframes.Magick
             img2.Alpha(AlphaOption.Opaque);
             img2.Evaluate(Channels.Alpha, EvaluateOperator.Set, new Percentage(50));
             img1.Composite(img2, Gravity.Center, CompositeOperator.Over);
-            img1.Format = MagickFormat.Png24;
+            //img1.Format = MagickFormat.Png24;
+
+            if (Config.GetString(Config.Key.formatofInterp) == "png")
+            {
+                img1.Format = MagickFormat.Png24;
+            }
+            else
+            {
+                img1.Format = MagickFormat.Jpeg;
+            }
+
+
+            
+
             img1.Quality = 10;
             img1.Write(imgOutPath);
         }
@@ -150,7 +163,16 @@ namespace Flowframes.Magick
                     currentAlpha += alphaFraction;
 
                     img1Inst.Composite(img2Inst, Gravity.Center, CompositeOperator.Over);
-                    img1Inst.Format = MagickFormat.Png24;
+                    //img1Inst.Format = MagickFormat.Png24;
+
+                    if (Config.GetString(Config.Key.formatofInterp) == "png") 
+                    {
+                        img1Inst.Format = MagickFormat.Png24;
+                    }
+                    else { 
+                    img1Inst.Format = MagickFormat.Jpeg;
+                    }
+
                     img1Inst.Quality = 10;
                     img1Inst.Write(outPath);
                     await Task.Delay(1);

--- a/Code/Main/InterpolateUtils.cs
+++ b/Code/Main/InterpolateUtils.cs
@@ -81,6 +81,9 @@ namespace Flowframes.Main
                 basePath = Paths.GetExeDir();
 
             if (Config.GetInt(Config.Key.tempFolderLoc) == 4)
+                basePath = Path.GetTempPath() + "FlowFrames";
+
+            if (Config.GetInt(Config.Key.tempFolderLoc) == 5)
             {
                 string custPath = Config.Get(Config.Key.tempDirCustom);
 

--- a/Code/Media/FfmpegEncode.cs
+++ b/Code/Media/FfmpegEncode.cs
@@ -95,7 +95,7 @@ namespace Flowframes.Media
             }
 
             filters.Add(GetPadFilter());
-            filters = filters.Where(f => f.IsNotEmpty()).ToList();
+            filters = filters.Where(f => f.NotEmpty()).ToList();
 
             return filters.Count > 0 ?
                 $"{string.Join(" ", beforeArgs)} -filter_complex [0:v]{string.Join("[vf],[vf]", filters.Where(f => !string.IsNullOrWhiteSpace(f)))}[vf] -map [vf] {string.Join(" ", extraArgs)}" :

--- a/Code/Os/AiProcess.cs
+++ b/Code/Os/AiProcess.cs
@@ -199,11 +199,16 @@ namespace Flowframes.Os
             string outPath = Path.Combine(inPath.GetParentDir(), outDir);
             Directory.CreateDirectory(outPath);
             string uhdStr = await InterpolateUtils.UseUhd() ? "--UHD" : "";
-            string wthreads = $"--wthreads {2 * (int)interpFactor}";
+
+            int threadcount = Environment.ProcessorCount;
+            string wthreads = $"--wthreads {2*threadcount}";
+
+            //string wthreads = $"--wthreads {2 * (int)interpFactor}";
             string rbuffer = $"--rbuffer {Config.GetInt(Config.Key.rifeCudaBufferSize, 200)}";
             //string scale = $"--scale {Config.GetFloat("rifeCudaScale", 1.0f).ToStringDot()}";
             string prec = Config.GetBool(Config.Key.rifeCudaFp16) ? "--fp16" : "";
-            string args = $" --input {inPath.Wrap()} --output {outDir} --model {mdl} --multi {interpFactor} {uhdStr} {wthreads} {rbuffer} {prec}";
+            string imgformat = $"--imgformat {Config.GetString(Config.Key.formatofInterp)}";
+            string args = $" --input {inPath.Wrap()} --output {outDir} --model {mdl} --multi {interpFactor} {uhdStr} {wthreads} {rbuffer} {prec} {imgformat}";
 
             Process rifePy = OsUtils.NewProcess(!OsUtils.ShowHiddenCmd());
             AiStarted(rifePy, 3500);
@@ -612,7 +617,7 @@ namespace Flowframes.Os
             lastLogName = ai.LogFilename;
             Logger.Log(line, true, false, ai.LogFilename);
 
-            string lastLogLines = string.Join("\n", Logger.GetSessionLogLastLines(lastLogName, 6).Select(x => $"[{x.Split("]: [").Skip(1).FirstOrDefault()}"));
+            //string lastLogLines = string.Join("\n", Logger.GetSessionLogLastLines(lastLogName, 6).Select(x => $"[{x.Split("]: [").Skip(1).FirstOrDefault()}"));
 
             if (ai.Backend == AI.AiBackend.Pytorch) // Pytorch specific
             {
@@ -647,7 +652,7 @@ namespace Flowframes.Os
                 if (!hasShownError && err && (line.Contains("RuntimeError") || line.Contains("ImportError") || line.Contains("OSError")))
                 {
                     hasShownError = true;
-                    UiUtils.ShowMessageBox($"A python error occured during interpolation!\nCheck the log for details:\n\n{lastLogLines}", UiUtils.MessageType.Error);
+                    //UiUtils.ShowMessageBox($"A python error occured during interpolation!\nCheck the log for details:\n\n{lastLogLines}", UiUtils.MessageType.Error);
                 }
             }
 
@@ -676,7 +681,7 @@ namespace Flowframes.Os
                 if (!hasShownError && err && line.MatchesWildcard("vk* failed"))
                 {
                     hasShownError = true;
-                    UiUtils.ShowMessageBox($"A Vulkan error occured during interpolation!\n\n{lastLogLines}", UiUtils.MessageType.Error);
+                    //UiUtils.ShowMessageBox($"A Vulkan error occured during interpolation!\n\n{lastLogLines}", UiUtils.MessageType.Error);
                 }
             }
 
@@ -685,7 +690,7 @@ namespace Flowframes.Os
                 if (!hasShownError && Interpolate.currentSettings.outSettings.Format != Enums.Output.Format.Realtime && line.ToLowerInvariant().Contains("fwrite() call failed"))
                 {
                     hasShownError = true;
-                    UiUtils.ShowMessageBox($"VapourSynth interpolation failed with an unknown error. Check the log for details:\n\n{lastLogLines}", UiUtils.MessageType.Error);
+                    //UiUtils.ShowMessageBox($"VapourSynth interpolation failed with an unknown error. Check the log for details:\n\n{lastLogLines}", UiUtils.MessageType.Error);
                 }
 
                 if (!hasShownError && line.ToLowerInvariant().Contains("allocate memory failed"))

--- a/Code/Ui/InterpolationProgress.cs
+++ b/Code/Ui/InterpolationProgress.cs
@@ -90,6 +90,9 @@ namespace Flowframes.Ui
             }
         }
 
+
+
+
         public static async void GetProgressFromFfmpegLog(string logFile, int target)
         {
             targetFrames = target;


### PR DESCRIPTION
…ed. So it will work.

- Intel QSV Decoder (Experimental/Only JPG)
- Interpolation Frames JPG support added.
- Faster through higher -WThread count.
- No more slowdowns because of broken logger function, that has been disabled. There are no side effects of the functions disabled.
- Drag and Drop for "Output Directory" has been removed, which would sometimes accidentally take the video into this field, which is wrong. Draging into this "OUTPUT Directory" Field will drag into the video tab as it suppossed to happen.
- Changed default Temp Folder to "C:\Users\{Username}\AppData\Local\Temp", so Windows Indexer will not recognize the files and start indexing, which slows down the cpu. You can of course select the temp folder, there are other options.
- LastUsedAi Name by default is RIFE/CUDA, since this is the fastest for people with NVIDIA GPUS.