### PR TITLE
Keep only 10 lines for in memory session logs

### DIFF
--- a/Code/IO/Logger.cs
+++ b/Code/IO/Logger.cs
@@ -18,7 +18,7 @@ namespace Flowframes
         public const string defaultLogName = "sessionlog";
         public static long id;
 
-        private static Dictionary<string, string> sessionLogs = new Dictionary<string, string>();
+        private static Dictionary<string, List<string>> sessionLogs = new Dictionary<string, List<string>>();
         private static string _lastUi = "";
         public static string LastUiLine { get { return _lastUi; } }
         private static string _lastLog = "";
@@ -116,7 +116,12 @@ namespace Flowframes
             try
             {
                 string appendStr = noLineBreak ? $" {logStr}" : $"{Environment.NewLine}[{id.ToString().PadLeft(8, '0')}] [{time}]: {logStr}";
-                sessionLogs[filename] = (sessionLogs.ContainsKey(filename) ? sessionLogs[filename] : "") + appendStr;
+                //sessionLogs[filename] = (sessionLogs.ContainsKey(filename) ? sessionLogs[filename] : "") + appendStr;
+                List<string> sessionLog = (sessionLogs.ContainsKey(filename) ? sessionLogs[filename] : new List<string>());
+                sessionLog.Add(appendStr);
+                if (sessionLog.Count > 10)
+                    sessionLog.RemoveAt(0);
+                sessionLogs[filename] = sessionLog;
                 File.AppendAllText(file, appendStr);
                 id++;
             }
@@ -126,7 +131,7 @@ namespace Flowframes
             }
         }
 
-        public static string GetSessionLog(string filename)
+        public static List<string> GetSessionLog(string filename)
         {
             if (!filename.Contains(".txt"))
                 filename = Path.ChangeExtension(filename, "txt");
@@ -134,14 +139,15 @@ namespace Flowframes
             if (sessionLogs.ContainsKey(filename))
                 return sessionLogs[filename];
             else
-                return "";
+                return new List<string>();
         }
 
         public static List<string> GetSessionLogLastLines(string filename, int linesCount = 5)
         {
-            string log = GetSessionLog(filename);
-            string[] lines = log.SplitIntoLines();
-            return lines.Reverse().Take(linesCount).Reverse().ToList();
+            List<string> log = GetSessionLog(filename);
+            //string[] lines = log.SplitIntoLines();
+            //return lines.Reverse().Take(linesCount).Reverse().ToList();
+            return log.Count > linesCount ? log.GetRange(0, linesCount) : log;
         }
 
         public static void LogIfLastLineDoesNotContainMsg(string s, bool hidden = false, bool replaceLastLine = false, string filename = "")


### PR DESCRIPTION
The in-memory logs are getting very big for long processing sessions with big impact on performance. The speed is halved after few hours. So, keep only 10 lines for in-memory session logs, without impact on functionality.